### PR TITLE
Implement default English, logo link, and mobile styles

### DIFF
--- a/src/app/components/layout/layout.component.html
+++ b/src/app/components/layout/layout.component.html
@@ -1,5 +1,5 @@
 <header class="navbar">
-  <div class="logo">Akordirect</div>
+  <div class="logo" (click)="scrollToMain()">Akor Direct</div>
   <nav class="nav-links">
     <a href="#aboutCompany">{{ 'О компании' | translate }}</a>
     <a href="#services">{{ 'Услуги' | translate }}</a>

--- a/src/app/components/layout/layout.component.scss
+++ b/src/app/components/layout/layout.component.scss
@@ -48,3 +48,26 @@
   padding: 0.5rem 1rem;
   cursor: pointer;
 }
+
+@media (max-width: 600px) {
+  .navbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .logo {
+    margin-left: 1rem;
+    font-size: 2rem;
+  }
+
+  .nav-links {
+    flex-direction: column;
+    margin: 1rem 0;
+    gap: 1rem;
+  }
+
+  .nav-links a {
+    margin-left: 0;
+    padding: 0.5rem 1rem;
+  }
+}

--- a/src/app/components/layout/layout.component.ts
+++ b/src/app/components/layout/layout.component.ts
@@ -12,4 +12,11 @@ export class LayoutComponent {
   setLang(lang: 'ru' | 'en') {
     this.langService.setLanguage(lang);
   }
+
+  scrollToMain() {
+    const anchor = document.querySelector('#main');
+    if (anchor) {
+      anchor.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
 }

--- a/src/app/services/language.service.ts
+++ b/src/app/services/language.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class LanguageService {
-  currentLang: 'ru' | 'en' = 'ru';
+  currentLang: 'ru' | 'en' = 'en';
 
   private translations: Record<string, { en: string }> = {
     'Digital-агенство с экспертизой в': { en: 'Digital agency with expertise in' },

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -56,3 +56,10 @@ $vmccnc-web-angular-theme: mat.define-light-theme((
 
 html, body { height: 100%; }
 body { margin: 0; font-family: 'TT Travels', sans-serif; background-color: #f9f8f8; max-width: 1920px;}
+
+@media (max-width: 600px) {
+  h1 { font-size: 1.5rem; }
+  h2 { font-size: 2rem; }
+  h3 { font-size: 1.5rem; }
+  p  { font-size: 1rem; }
+}


### PR DESCRIPTION
## Summary
- default to English in LanguageService
- make the logo navigate to the main section
- add responsive styles for the layout and basic typography

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*