### PR TITLE
Fix project card layout after anchor conversion

### DIFF
--- a/src/app/components/project-list/project/project.component.scss
+++ b/src/app/components/project-list/project/project.component.scss
@@ -1,4 +1,6 @@
 .card {
+  display: block;
+  text-decoration: none;
   border: 1px solid #ddd;
   border-radius: 2rem;
   margin: 10px;


### PR DESCRIPTION
## Summary
- ensure project cards render as blocks so wrapping works correctly

## Testing
- `npm test` *(fails: ng not found)*